### PR TITLE
Search by Name Page

### DIFF
--- a/rate_my_landlord/api/urls.py
+++ b/rate_my_landlord/api/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from .views import GetAllLandlords, main, CreateLandlordView, GetLandlord
+from .views import GetMatchingLandlords, main, CreateLandlordView, GetLandlordById
 
 urlpatterns = [
     path('', main),
     path('create-landlord', CreateLandlordView.as_view()),
-    path('get-landlord', GetLandlord.as_view()),
-    path('get-all-landlords', GetAllLandlords.as_view()),
+    path('get-landlord-by-id', GetLandlordById.as_view()),
+    path('get-matching-landlords', GetMatchingLandlords.as_view()),
 ]

--- a/rate_my_landlord/api/urls.py
+++ b/rate_my_landlord/api/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import GetMatchingLandlords, main, CreateLandlordView, GetLandlordById
+from .views import GetMatchingLandlords, main, CreateLandlordView, GetLandlordById, GetAllLandlords
 
 urlpatterns = [
     path('', main),
     path('create-landlord', CreateLandlordView.as_view()),
     path('get-landlord-by-id', GetLandlordById.as_view()),
+    path('get-all-landlords', GetAllLandlords.as_view()),
     path('get-matching-landlords', GetMatchingLandlords.as_view()),
 ]

--- a/rate_my_landlord/api/urls.py
+++ b/rate_my_landlord/api/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from .views import LandlordView, main, CreateLandlordView, GetLandlord
+from .views import GetAllLandlords, main, CreateLandlordView, GetLandlord
 
 urlpatterns = [
     path('', main),
-    path('home', LandlordView.as_view()),
     path('create-landlord', CreateLandlordView.as_view()),
-    path('get-landlord', GetLandlord.as_view())
+    path('get-landlord', GetLandlord.as_view()),
+    path('get-all-landlords', GetAllLandlords.as_view()),
 ]

--- a/rate_my_landlord/api/views.py
+++ b/rate_my_landlord/api/views.py
@@ -40,6 +40,13 @@ class GetLandlordById(APIView):
                return Response({'Landlord Not Found': 'Invalid ID'}, status=status.HTTP_404_NOT_FOUND)
           return Response({'Bad Request': 'ID parameter not found in request'}, status=status.HTTP_400_BAD_REQUEST)
 
+class GetAllLandlords(APIView):
+     serializer_class = LandlordSerializer
+     def get(self, request, format=None):
+          queryset = Landlord.objects.all()
+          data = LandlordSerializer(queryset, many=True).data
+          return Response(data, status=status.HTTP_200_OK)
+
 class GetMatchingLandlords(APIView):
      serializer_class = LandlordSerializer
      lookup_url_kwarg = 'searchkey'

--- a/rate_my_landlord/api/views.py
+++ b/rate_my_landlord/api/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from rest_framework import generics, status
+from rest_framework import status
 from .models import Landlord
 from .serializers import LandlordSerializer, CreateLandlordSerializer
 from django.http import HttpResponse
@@ -9,25 +9,6 @@ from rest_framework.response import Response
 
 def main(request):
      return HttpResponse("<h1>Hello</h1>")
-
-class LandlordView(generics.ListAPIView):
-    queryset = Landlord.objects.all()
-    serializer_class = LandlordSerializer
-
-class GetLandlord(APIView):
-     serializer_class = LandlordSerializer
-     lookup_url_kwarg = 'id'
-
-     def get(self, request, format=None):
-          id = request.GET.get(self.lookup_url_kwarg)
-          if id != None:
-               landlord = Landlord.objects.filter(id=id)
-               if len(landlord) > 0:
-                    data = LandlordSerializer(landlord[0]).data
-                    return Response(data, status=status.HTTP_200_OK)
-               return Response({'Landlord Not Found': 'Invalid ID'}, status=status.HTTP_404_NOT_FOUND)
-          return Response({'Bad Request': 'ID parameter not found in request'}, status=status.HTTP_400_BAD_REQUEST)
-
 
 # APIView has default get and post methods that we can override
 class CreateLandlordView(APIView):
@@ -42,3 +23,25 @@ class CreateLandlordView(APIView):
           new_landlord = Landlord(first_name=landlord_first_name, last_name=landlord_last_name)
           new_landlord.save()
           return Response(LandlordSerializer(new_landlord).data, status=status.HTTP_201_CREATED)
+
+# APIView has default get and post methods that we can override
+class GetLandlord(APIView):
+     serializer_class = LandlordSerializer
+     lookup_url_kwarg = 'id'
+     # Handles a get request from frontend
+     def get(self, request, format=None):
+          id = request.GET.get(self.lookup_url_kwarg)
+          if id != None:
+               landlord = Landlord.objects.filter(id=id)
+               if len(landlord) > 0:
+                    data = LandlordSerializer(landlord[0]).data
+                    return Response(data, status=status.HTTP_200_OK)
+               return Response({'Landlord Not Found': 'Invalid ID'}, status=status.HTTP_404_NOT_FOUND)
+          return Response({'Bad Request': 'ID parameter not found in request'}, status=status.HTTP_400_BAD_REQUEST)
+
+class GetAllLandlords(APIView):
+    serializer_class = LandlordSerializer
+    def get(self, request, format=None):
+         queryset = Landlord.objects.all()
+         data = LandlordSerializer(queryset, many=True).data
+         return Response(data, status=status.HTTP_200_OK)

--- a/rate_my_landlord/frontend/src/components/LandlordDisplayPage.js
+++ b/rate_my_landlord/frontend/src/components/LandlordDisplayPage.js
@@ -12,7 +12,7 @@ export default class LandlordDisplayPage extends Component {
     }
 
     getLandlordDetails = () => {
-        fetch('/api/get-landlord?id=' + this.landlordID)
+        fetch('/api/get-landlord-by-id?id=' + this.landlordID)
             .then((response) => response.json())
             .then((data) => this.setState({
                 firstName: data.first_name,

--- a/rate_my_landlord/frontend/src/components/SearchByNamePage.js
+++ b/rate_my_landlord/frontend/src/components/SearchByNamePage.js
@@ -1,30 +1,89 @@
 import React, { Component } from 'react';
-import { Grid, List, ListItem, ListItemText, Typography } from '@material-ui/core';
+import { Grid, List, ListItem, ListItemText, IconButton, InputAdornment, TextField, Typography } from '@material-ui/core';
+import { Search } from '@material-ui/icons';
 
 export default class SearchByNamePage extends Component {
     constructor(props) {
         super(props)
         this.state = {
             searchResults: [],
+            currSearchKey: "",
+            submittedSearchKey: "",
+            noMatches: false,
         }
-        this.getMatchingLandlords();
     }
 
-    getMatchingLandlords = () => {
-        fetch('/api/get-all-landlords')
+    onSubmitSearch = () => {
+        fetch('/api/get-matching-landlords?searchkey=' + this.state.currSearchKey)
         .then((response) => response.json())
-        .then((data) => this.setState({
-            searchResults: data,
-        }));
+        .then((data) => {
+            console.log(data);
+            console.log(data.length);
+            if (data.length === 0) {
+                this.setState({
+                    searchResults: [],
+                    noMatches: true,
+                    submittedSearchKey: this.state.currSearchKey,
+                });
+            } else {
+                this.setState({
+                    searchResults: data,
+                    noMatches: false,
+                    submittedSearchKey: this.state.currSearchKey,
+                });
+            }
+        });
+    }
+
+    onEditSearch = (e) => {
+        this.setState({
+            currSearchKey: e.target.value,
+        });
     }
 
     render() {
+        let renderSearchBar = (
+            <TextField 
+                label="Search Landlords"
+                onChange={this.onEditSearch}
+                onKeyDown={(e) => {if (e.key === 'Enter') this.onSubmitSearch();}}
+                InputProps={{
+                    endAdornment: (
+                        <InputAdornment>
+                            <IconButton 
+                                aria-label="Submit Search"
+                                onClick={this.onSubmitSearch}
+                            >
+                                <Search />
+                            </IconButton>
+                        </InputAdornment>
+                    )
+                }}
+            />
+        );
+        let renderNoMatchError = (
+            <React.Fragment>
+                &emsp;
+                <Typography component='h5' variant="h5">
+                    No search results found for "{this.state.submittedSearchKey}"
+                </Typography>
+            </React.Fragment>
+        );
+        let renderShortSearchError = (
+            <Typography component='h5' variant="h5">
+                No search results found for "{this.state.submittedSearchKey}"
+            </Typography>
+        );
         let renderSearchResults = this.state.searchResults.map(
             (result) => {
                 return (
-                    <ListItem button component="a" href="/landlord/1">
+                    <ListItem button component="a" href={"/landlord/" + result.id}>
                         <ListItemText
-                            primary={result.first_name + " " + result.last_name}
+                            primary={
+                                <Typography component='h5' variant="h5">
+                                    {result.first_name + " " + result.last_name}
+                                </Typography>
+                            }
                         />
                     </ListItem>
                 );
@@ -32,10 +91,9 @@ export default class SearchByNamePage extends Component {
         );
         return (
             <Grid container spacing={2}>
-                <Grid item xs={12} align="center">
-                    <Typography component='h4' variant="h4">
-                        Search Results For xx
-                    </Typography>
+                <Grid item xs={12} align="center">{renderSearchBar}</Grid>
+                <Grid item xs={12} align="center" style={{ display: this.state.noMatches ? "" : "none" }}>
+                    {renderNoMatchError}
                 </Grid>
                 <Grid item xs={12} align="center">
                     <List>{renderSearchResults}</List>

--- a/rate_my_landlord/frontend/src/components/SearchByNamePage.js
+++ b/rate_my_landlord/frontend/src/components/SearchByNamePage.js
@@ -1,11 +1,46 @@
 import React, { Component } from 'react';
+import { Grid, List, ListItem, ListItemText, Typography } from '@material-ui/core';
 
 export default class SearchByNamePage extends Component {
     constructor(props) {
         super(props)
+        this.state = {
+            searchResults: [],
+        }
+        this.getMatchingLandlords();
+    }
+
+    getMatchingLandlords = () => {
+        fetch('/api/get-all-landlords')
+        .then((response) => response.json())
+        .then((data) => this.setState({
+            searchResults: data,
+        }));
     }
 
     render() {
-        return <p>This is the search by name page</p>;
+        let renderSearchResults = this.state.searchResults.map(
+            (result) => {
+                return (
+                    <ListItem button component="a" href="/landlord/1">
+                        <ListItemText
+                            primary={result.first_name + " " + result.last_name}
+                        />
+                    </ListItem>
+                );
+            }
+        );
+        return (
+            <Grid container spacing={2}>
+                <Grid item xs={12} align="center">
+                    <Typography component='h4' variant="h4">
+                        Search Results For xx
+                    </Typography>
+                </Grid>
+                <Grid item xs={12} align="center">
+                    <List>{renderSearchResults}</List>
+                </Grid>
+            </Grid>
+        );
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==3.2.7
 djangorestframework==3.12.4
 factory-boy==3.2.0
+fuzzywuzzy==0.17.0


### PR DESCRIPTION
### Changes in this PR
- can test the added `getAllLandlords` backend (`ratemylandlord/rate_my_landlord/api/views.py`) function at {localhost url}/api/get-all-landlords
- can test the `getMatchingLandlords` backend (`ratemylandlord/rate_my_landlord/api/views.py`)  function at {localhost url}/api/get-matching-landlords?searchkey={search key}
- added frontend search components to `ratemylandlord/rate_my_landlord/frontend/src/components/SearchByNamePage.js`

### Changes Made Screenshots
Example of empty search -- show all landlords:
![empty search](https://user-images.githubusercontent.com/43322572/140826575-319f6759-05e6-418f-acbd-f00f73af02c9.png)
Example of normal search:
![search ex](https://user-images.githubusercontent.com/43322572/140826578-f6a1448f-9871-41b7-895c-8673ec1e4951.png)
Clicking onto a name brings you to do the landlord display page (which is not developed yet):
![landlord display page](https://user-images.githubusercontent.com/43322572/140826577-76c4f7f2-26d9-4493-adb4-d68b15ec5bda.png)

